### PR TITLE
chore: use ipfs/kubo:v0.14.0 as source image

### DIFF
--- a/gateway-copilot-backend-service/Dockerfile
+++ b/gateway-copilot-backend-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ipfs/go-ipfs:master-2022-04-22-d6077b8
+FROM ipfs/kubo:v0.14.0
 
 ADD ipfs-config.sh /container-init.d/ipfs-config.sh
 RUN chmod a+x /container-init.d/ipfs-config.sh

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM ipfs/go-ipfs:master-2022-04-22-d6077b8
+FROM ipfs/kubo:v0.14.0
 
 ADD ipfs-config.sh /container-init.d/ipfs-config.sh
 RUN chmod a+x /container-init.d/ipfs-config.sh


### PR DESCRIPTION
support for container initialisation in docker landed in v0.13.0 and the canonical image was renmaned ipfs/kubo at v0.14.0

see: https://github.com/ipfs/kubo/releases/tag/v0.13.0#custom-init-docker
see: https://github.com/ipfs/kubo/releases/tag/v0.14.0

fixes #1

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>